### PR TITLE
fix: improve missing scenario error handling

### DIFF
--- a/api-tests/step_definitions/support/dataStore.js
+++ b/api-tests/step_definitions/support/dataStore.js
@@ -45,7 +45,7 @@ class dataStore {
                             }
                         }
                     }
-                    throw new error('Scenario Name doesn\'t exists')
+                    throw new Error('Scenario Name doesn\'t exist')
     }
 
     retrieveRequestHeaders(scenarioName){

--- a/test/dataStore.spec.js
+++ b/test/dataStore.spec.js
@@ -1,0 +1,11 @@
+const { expect } = require('chai');
+const DataStore = require('../api-tests/step_definitions/support/dataStore');
+
+describe('dataStore', () => {
+  it('throws a descriptive error when scenario is missing', () => {
+    process.env.NODE_ENV = 'testing';
+    const ds = new DataStore(() => {}, () => {}, {});
+    const missingScenario = () => ds.retrieveRequestHeaders('Unknown Scenario');
+    expect(missingScenario).to.throw(Error, "Scenario Name doesn't exist");
+  });
+});


### PR DESCRIPTION
## Summary
- use `Error` constructor for missing scenario in dataStore
- add unit test verifying error message

## Testing
- `npx mocha`
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68aa5eef964c83278d2d97412c89e2ec